### PR TITLE
Remove pinning on CMake 3.20

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,8 +19,7 @@ build:
 
 requirements:
   build:
-    # CMake pinned as a workaround for https://github.com/conda-forge/scalapack-feedstock/pull/21#issuecomment-892033610
-    - cmake 3.20
+    - cmake
     - {{ compiler('fortran') }}
     - {{ compiler('c') }}
     - make


### PR DESCRIPTION
As the `fortranlibs` problem was solved as mentioned in https://github.com/conda-forge/scalapack-feedstock/pull/21#issuecomment-892663167 .

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.
